### PR TITLE
containerize crawler, responder and redis

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,9 +4,13 @@
 go test -v ./... &&
   go build -v ./... &&
   go fmt ./... &&
-  go mod tidy && goimports -w -local crawler cmd pkg
+  go mod tidy && goimports -w -local crawler cmd pkg &&
+  gofmt -l -e -d -s cmd/ pkg/
 
 # build
 mkdir -p bin &&
   go build -o bin/crawler cmd/service/main.go &&
-  go build -o bin/responder cmd/test/responder/*
+  go build -o bin/responder cmd/test/responder/*.go
+
+# docker
+docker-compose build

--- a/cmd/service/Dockerfile
+++ b/cmd/service/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:alpine AS builder
+WORKDIR /work/
+COPY . .
+RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o ./bin/crawler ./cmd/service/main.go
+
+
+FROM golang:alpine
+WORKDIR /project/
+COPY --from=builder /work/bin/crawler .
+RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+CMD ["./crawler"]

--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -18,16 +18,19 @@ import (
 )
 
 const (
-	defaultLimit = 1024 * 1024
+	defaultLimit = 1024 * 256
 	redisEnvVar  = "REDIS_URL"
+	portEnvVar   = "PORT"
 )
 
 func main() {
-	var ip, port string
+	port := os.Getenv(portEnvVar)
+	if port == "" {
+		log.Fatalf("%s variable not set\n", portEnvVar)
+	}
+
 	var limit int
 
-	flag.StringVar(&port, "port", "8080", "http port to listen on")
-	flag.StringVar(&ip, "ip", "0.0.0.0", "ip address to bind to")
 	flag.IntVar(&limit, "limit", defaultLimit, "payload limit")
 	flag.Parse()
 
@@ -70,7 +73,7 @@ func main() {
 
 	sizeLimiter := handler.NewSizeLimiter(limit)
 
-	addr := net.JoinHostPort(ip, port)
+	addr := net.JoinHostPort("", port)
 	log.Printf("listening on: %s\n", addr)
 
 	err := http.ListenAndServe(addr, handler.NewChain(router, sizeLimiter))

--- a/cmd/test/responder/Dockerfile
+++ b/cmd/test/responder/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:alpine AS builder
+WORKDIR /work/
+COPY . .
+RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o ./bin/responder ./cmd/test/responder/*.go
+
+
+FROM golang:alpine
+WORKDIR /project/
+COPY --from=builder /work/bin/responder .
+RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+CMD ["./responder"]

--- a/cmd/test/responder/main.go
+++ b/cmd/test/responder/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"net"
 	"net/http"
+	"os"
 
 	"github.com/gorilla/mux"
 )
@@ -14,13 +14,14 @@ const (
 	sizeLimit    = 1024 * 1024
 	sizeParam    = "size"
 	rangePath    = "/range/{" + sizeParam + "}"
+	portEnvVar   = "PORT"
 )
 
 func main() {
-	var port string
-
-	flag.StringVar(&port, "port", "8080", "http port to listen on")
-	flag.Parse()
+	port := os.Getenv(portEnvVar)
+	if port == "" {
+		log.Fatalf("%s variable not set\n", portEnvVar)
+	}
 
 	r := mux.NewRouter()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+
+services:
+
+  # rest api service
+  crawler:
+    build:
+      context: .
+      dockerfile: cmd/service/Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      REDIS_URL: redis://redis:6379
+      PORT: 8080
+    depends_on:
+      - responder
+      - redis
+
+  # simple http responder (for testing in offline mode)
+  responder:
+    build:
+      context: .
+      dockerfile: cmd/test/responder/Dockerfile
+    environment:
+      PORT: 8080
+
+  # redis DB
+  redis:
+    image: redis:alpine
+


### PR DESCRIPTION
Containerize: crawler, responder and redis.

`docker-compose` is used as an orchestrator.